### PR TITLE
fix: validate price before adding to cart

### DIFF
--- a/script.js
+++ b/script.js
@@ -2,7 +2,12 @@
 const cart = [];
 
 function addToCart(name, price) {
-  cart.push({ name, price });
+  const numericPrice = Number(price);
+  if (Number.isNaN(numericPrice)) {
+    console.warn('Invalid price passed to addToCart:', price);
+    return;
+  }
+  cart.push({ name, price: numericPrice });
   renderCart();
 }
 


### PR DESCRIPTION
## Summary
- Guard against invalid price values when adding items to the cart
- Coerce prices to numbers and warn on invalid inputs to avoid runtime errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5fd7e730832fb5262e95ce59c0c9